### PR TITLE
Add automatic language detection to code blocks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@ LLM, and to quickly edit what's included in the subset.
 ![1](https://raw.githubusercontent.com/FraserLee/readme_resources/main/screenshot%204.png)
 
 ## Installation
+
 ```sh
 # clone the repo
 git clone https://github.com/FraserLee/synopsis
@@ -27,8 +28,10 @@ synopsis # copy every file listed in `.llm_info`, wrapped in code blocks, to
 
 synopsis --edit # interactively add and remove files from `.llm_info`
 ```
+
 This creates a file, `.llm_info`, which looks like
-```
+
+```txt
 file1.txt
 foo/bar/file2.txt
 etc.
@@ -37,17 +40,13 @@ etc.
 The clipboard output is formatted as
 
 ````markdown
-```
 file1.txt
-```
-```
+```txt
 file 1 contents
 ```
 
-```
 foo/bar/file2.txt
-```
-```
+```txt
 file 2 contents
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -32,21 +32,21 @@ synopsis --edit # interactively add and remove files from `.llm_info`
 This creates a file, `.llm_info`, which looks like
 
 ```txt
-file1.txt
-foo/bar/file2.txt
+file1.md
+foo/bar/file2.py
 etc.
 ```
 
 The clipboard output is formatted as
 
 ````markdown
-file1.txt
-```txt
+file1.md
+```markdown
 file 1 contents
 ```
 
-foo/bar/file2.txt
-```txt
+foo/bar/file2.py
+```python
 file 2 contents
 ```
 

--- a/synopsis.py
+++ b/synopsis.py
@@ -325,9 +325,12 @@ def get_language_hint(filename: str) -> str:
     """Return a language hint for syntax highlighting based on the filename.
 
     The logic works as follows:
-    - Special cases are handled using `_SPECIAL_FILENAMES`. E.g. "CMakeLists.txt" -> "cmake".
-    - Standard extensions are mapped using `_LANGUAGE_MAP`. E.g. "py" -> "python".
-    - The rest are mapped to their extension. E.g. "foo.bar" -> "bar".
+    - Special cases are handled using `_SPECIAL_FILENAMES`.
+      E.g. "CMakeLists.txt" -> "cmake".
+    - Standard extensions are mapped using `_LANGUAGE_MAP`.
+      E.g. "py" -> "python".
+    - The rest are mapped to their extension.
+      E.g. "foo.bar" -> "bar".
 
     Args:
         filename: Input filename to analyze, can include path components

--- a/synopsis.py
+++ b/synopsis.py
@@ -260,101 +260,74 @@ except Exception:
 
 # ----------------------------- build final output -----------------------------
 
-_LANGUAGE_MAP: Dict[str, str] = {
-    "jsx": "jsx",
-    "tsx": "tsx",
-    "css": "css",
-    "less": "less",
-    "json": "json",
-    "html": "html",
-    "xml": "xml",
-    "yaml": "yaml",
-    "yml": "yml",
-    "toml": "toml",
-    "ini": "ini",
-    "cfg": "ini",
-    "conf": "ini",
-    "gradle": "gradle",
-    "php": "php",
-    "swift": "swift",
-    "sql": "sql",
-    "go": "go",
-    "java": "java",
-    "c": "c",
-    "cpp": "cpp",
-    "r": "r",
-    "rmd": "rmd",
-    "scala": "scala",
-    "hs": "haskell",
-    "elm": "elm",
-    "erl": "erlang",
-    "ex": "elixir",
-    "exs": "elixir",
-    "clj": "clojure",
-    "cljs": "clojure",
-    "vue": "vue",
-    "svelte": "svelte",
-    "mdx": "mdx",
-    "bat": "bat",
-    "groovy": "groovy",
-    "nim": "nim",
-    "v": "verilog",
-    "sv": "systemverilog",
-    "dart": "dart",
-    "fish": "fish",
-    "md": "markdown",
-    "py": "python",
-    "pyw": "python",
-    "pyi": "python",
-    "js": "javascript",
-    "mjs": "javascript",
-    "ts": "typescript",
-    "sh": "bash",
-    "bash": "bash",
-    "zsh": "bash",
-    "h": "c",
-    "hpp": "cpp",
-    "cs": "csharp",
-    "rs": "rust",
-    "rb": "ruby",
-    "erb": "ruby",
-    "pl": "perl",
-    "pm": "perl",
-    "kt": "kotlin",
-    "kts": "kotlin",
-    "coffee": "coffeescript",
-    "ps1": "powershell",
-    "psm1": "powershell",
-    "csx": "csharp",
-    "tex": "latex",
-    "mm": "objective-c++",
-    "f90": "fortran",
-    "f95": "fortran",
-    "jl": "julia",
-    "vhd": "vhdl",
-    "svh": "systemverilog",
-    "scss": "scss",
-    "sass": "sass",
-    "hbs": "handlebars",
-
-    # All other cases, like .txt, .log, etc. should be mapped to ""
-}
-
 _SPECIAL_FILENAMES: Dict[str, str] = {
-    "dockerfile": "dockerfile",
-    "makefile": "makefile",
-    "cmakelists.txt": "cmake",
     ".bash_profile": "bash",
     ".bashrc": "bash",
     ".zshrc": "bash",
-    "procfile": "yaml",
     "berksfile": "ruby",
+    "cmakelists.txt": "cmake",
+    "dockerfile": "dockerfile",
     "gemfile": "ruby",
+    "makefile": "makefile",
+    "procfile": "yaml",
     "vagrantfile": "ruby",
+}
+
+_LANGUAGE_MAP: Dict[str, str] = {
+    "bat": "bat",
+    "cfg": "ini",
+    "clj": "clojure",
+    "cljs": "clojure",
+    "coffee": "coffeescript",
+    "conf": "ini",
+    "cs": "csharp",
+    "csx": "csharp",
+    "erb": "ruby",
+    "erl": "erlang",
+    "ex": "elixir",
+    "exs": "elixir",
+    "f90": "fortran",
+    "f95": "fortran",
+    "groovy": "groovy",
+    "h": "c",
+    "hbs": "handlebars",
+    "hpp": "cpp",
+    "hs": "haskell",
+    "jl": "julia",
+    "js": "javascript",
+    "kt": "kotlin",
+    "kts": "kotlin",
+    "log": "",
+    "md": "markdown",
+    "mjs": "javascript",
+    "mm": "objective-c++",
+    "pl": "perl",
+    "pm": "perl",
+    "ps1": "powershell",
+    "psm1": "powershell",
+    "py": "python",
+    "pyi": "python",
+    "pyw": "python",
+    "rb": "ruby",
+    "rs": "rust",
+    "sh": "bash",
+    "sv": "systemverilog",
+    "svh": "systemverilog",
+    "tex": "latex",
+    "ts": "typescript",
+    "txt": "",
+    "v": "verilog",
+    "vhd": "vhdl",
+    "zsh": "bash",
 }
 
 def get_language_hint(filename: str) -> str:
     """Return a language hint for syntax highlighting based on the filename.
+
+    The logic works as follows:
+    - Special cases are handled using `_SPECIAL_FILENAMES`. E.g. "CMakeLists.txt" -> "cmake".
+    - Standard extensions are mapped using `_LANGUAGE_MAP`. E.g. "py" -> "python".
+    - The rest are mapped to their extension. E.g. "foo.bar" -> "bar".
 
     Args:
         filename: Input filename to analyze, can include path components
@@ -371,7 +344,7 @@ def get_language_hint(filename: str) -> str:
     # Handle standard extensions
     _, ext = os.path.splitext(filename.lower())
     extension = ext.lstrip('.')
-    return _LANGUAGE_MAP.get(extension, "")
+    return _LANGUAGE_MAP.get(extension, extension)
 
 output_lines = []
 if args.tag:

--- a/synopsis.py
+++ b/synopsis.py
@@ -14,13 +14,6 @@ except ImportError:
     print("On Windows, there's some ways to go about installing it, but it's not there by default.")
     sys.exit(1)
 
-try:
-    from pygments.lexers import get_lexer_for_filename
-    from pygments.util import ClassNotFound
-    PYGMENTS_AVAILABLE = True
-except ImportError:
-    PYGMENTS_AVAILABLE = False
-
 selected_files: Set[str] = set()
 
 # ----------------------- build a copy of the filesystem -----------------------
@@ -269,15 +262,6 @@ except Exception:
 
 def get_language_hint(filename: str) -> str:
     """Return a language hint for syntax highlighting based on the filename."""
-    # Try pygments first if available
-    if PYGMENTS_AVAILABLE:
-        try:
-            lexer = get_lexer_for_filename(filename)
-            return lexer.aliases[0]  # use first alias as it's typically the most common name
-        except ClassNotFound:
-            pass  # fall back to extension-based detection
-
-    # Fallback to extension-based detection using os.path
     extension = os.path.splitext(filename.lower())[1][1:]
 
     # Extensions that are used directly as language hints.

--- a/synopsis.py
+++ b/synopsis.py
@@ -6,6 +6,8 @@ import argparse
 import platform
 import subprocess
 from typing import Optional, Set
+from pygments.lexers import get_lexer_for_filename
+from pygments.util import ClassNotFound
 
 try:
     import curses
@@ -280,9 +282,18 @@ for path in sorted(selected_files):
             content = ('\n' + content).replace("\n```", "\n\\`\\`\\`").strip()
     except Exception as e:
         content = f"[Error reading file: {e}]"
-    output_lines.append(f"```\n{path}\n```")
-    output_lines.append(f"```\n{content}\n```")
+
+    # Get language name from pygments
+    try:
+        lexer = get_lexer_for_filename(path)
+        lang_hint = lexer.aliases[0]  # use first alias as it's typically the most common name
+    except ClassNotFound:
+        lang_hint = ""
+
+    output_lines.append(f"\n{path}")
+    output_lines.append(f"```{lang_hint}\n{content}\n```")
     output_lines.append("")
+
 if args.tag:
     output_lines.append("</project>")
 

--- a/synopsis.py
+++ b/synopsis.py
@@ -5,7 +5,7 @@ import sys
 import argparse
 import platform
 import subprocess
-from typing import Optional, Set
+from typing import Dict, Optional, Set
 
 try:
     import curses
@@ -260,48 +260,118 @@ except Exception:
 
 # ----------------------------- build final output -----------------------------
 
+_LANGUAGE_MAP: Dict[str, str] = {
+    "jsx": "jsx",
+    "tsx": "tsx",
+    "css": "css",
+    "less": "less",
+    "json": "json",
+    "html": "html",
+    "xml": "xml",
+    "yaml": "yaml",
+    "yml": "yml",
+    "toml": "toml",
+    "ini": "ini",
+    "cfg": "ini",
+    "conf": "ini",
+    "gradle": "gradle",
+    "php": "php",
+    "swift": "swift",
+    "sql": "sql",
+    "go": "go",
+    "java": "java",
+    "c": "c",
+    "cpp": "cpp",
+    "r": "r",
+    "rmd": "rmd",
+    "scala": "scala",
+    "hs": "haskell",
+    "elm": "elm",
+    "erl": "erlang",
+    "ex": "elixir",
+    "exs": "elixir",
+    "clj": "clojure",
+    "cljs": "clojure",
+    "vue": "vue",
+    "svelte": "svelte",
+    "mdx": "mdx",
+    "bat": "bat",
+    "groovy": "groovy",
+    "nim": "nim",
+    "v": "verilog",
+    "sv": "systemverilog",
+    "dart": "dart",
+    "fish": "fish",
+    "md": "markdown",
+    "py": "python",
+    "pyw": "python",
+    "pyi": "python",
+    "js": "javascript",
+    "mjs": "javascript",
+    "ts": "typescript",
+    "sh": "bash",
+    "bash": "bash",
+    "zsh": "bash",
+    "h": "c",
+    "hpp": "cpp",
+    "cs": "csharp",
+    "rs": "rust",
+    "rb": "ruby",
+    "erb": "ruby",
+    "pl": "perl",
+    "pm": "perl",
+    "kt": "kotlin",
+    "kts": "kotlin",
+    "coffee": "coffeescript",
+    "ps1": "powershell",
+    "psm1": "powershell",
+    "csx": "csharp",
+    "tex": "latex",
+    "mm": "objective-c++",
+    "f90": "fortran",
+    "f95": "fortran",
+    "jl": "julia",
+    "vhd": "vhdl",
+    "svh": "systemverilog",
+    "scss": "scss",
+    "sass": "sass",
+    "hbs": "handlebars",
+
+    # All other cases, like .txt, .log, etc. should be mapped to ""
+}
+
+_SPECIAL_FILENAMES: Dict[str, str] = {
+    "dockerfile": "dockerfile",
+    "makefile": "makefile",
+    "cmakelists.txt": "cmake",
+    ".bash_profile": "bash",
+    ".bashrc": "bash",
+    ".zshrc": "bash",
+    "procfile": "yaml",
+    "berksfile": "ruby",
+    "gemfile": "ruby",
+    "vagrantfile": "ruby",
+}
+
 def get_language_hint(filename: str) -> str:
-    """Return a language hint for syntax highlighting based on the filename."""
-    extension = os.path.splitext(filename.lower())[1][1:]
+    """Return a language hint for syntax highlighting based on the filename.
 
-    # Extensions that are used directly as language hints.
-    self_mapping = {
-        "jsx", "tsx", "css", "less", "json", "md", "html", "xml",
-        "yaml", "yml", "toml", "ini", "cfg", "conf", "gradle", "php",
-        "swift", "sql", "go", "java", "c", "cpp", "r", "rmd", "scala",
-        "hs", "elm", "erl", "ex", "exs", "clj", "cljs", "vue", "svelte",
-        "mdx", "bat", "groovy", "nim", "v", "sv", "dart", "fish"
-    }
-    if extension in self_mapping:
-        return extension
+    Args:
+        filename: Input filename to analyze, can include path components
 
-    # Extensions that need explicit mapping.
-    language_map = {
-        "py": "python",
-        "js": "javascript",
-        "ts": "typescript",
-        "txt": "text",
-        "sh": "bash",
-        "bash": "bash",
-        "zsh": "bash",
-        "hpp": "cpp",
-        "cs": "csharp",
-        "rs": "rust",
-        "rb": "ruby",
-        "pl": "perl",
-        "kt": "kotlin",
-        "coffee": "coffeescript",
-        "ps1": "powershell",
-        "psm1": "powershell",
-        "csx": "csharp",
-        "tex": "latex",
-        "mm": "objective-c++",
-        "f90": "fortran",
-        "f95": "fortran",
-        "jl": "julia",
-        "vhd": "vhdl",
-    }
-    return language_map.get(extension, "")
+    Returns:
+        Language identifier string compatible with common syntax highlighters,
+        or empty string if no appropriate mapping exists.
+    """
+    # Check special filenames first
+    basename = os.path.basename(filename.lower())
+    if basename in _SPECIAL_FILENAMES:
+        return _SPECIAL_FILENAMES[basename]
+
+    # Handle standard extensions
+    _, ext = os.path.splitext(filename.lower())
+    extension = ext.lstrip('.')
+    return _LANGUAGE_MAP.get(extension, "")
 
 output_lines = []
 if args.tag:

--- a/synopsis.py
+++ b/synopsis.py
@@ -277,10 +277,8 @@ def get_language_hint(filename: str) -> str:
         except ClassNotFound:
             pass  # fall back to extension-based detection
 
-    # Fallback to extension-based detection
-    filename = filename.lower()
-    parts = filename.rsplit('.', 1)
-    extension = parts[-1] if len(parts) > 1 else ''
+    # Fallback to extension-based detection using os.path
+    extension = os.path.splitext(filename.lower())[1][1:]
 
     # Extensions that are used directly as language hints.
     self_mapping = {


### PR DESCRIPTION
Instead of producing:
```
Project structure:
'''
.
├── .gitignore
├── readme.md
└── synopsis.py
1 directory, 3 files
'''

Relevant files:
'''
.gitignore
'''
'''
.llm_info
'''

'''
readme.md
'''
'''
# synopsis.py
Small script to speed-copy some subset of files from a project into an into an
LLM, and to quickly edit what's included in the subset.
![1](https://raw.githubusercontent.com/FraserLee/readme_resources/main/screenshot%204.png)
## Installation
...
'''

'''
synopsis.py
'''
'''
#!/usr/bin/env python3
import os
import sys
import argparse
import platform
...
'''
```

I think it would make sense for it to produce:
```
Project structure:
'''
.
├── .gitignore
├── readme.md
└── synopsis.py
1 directory, 3 files
'''

Relevant files:

.gitignore
'''
.llm_info
'''

readme.md
'''markdown
# synopsis.py
Small script to speed-copy some subset of files from a project into an into an
LLM, and to quickly edit what's included in the subset.
![1](https://raw.githubusercontent.com/FraserLee/readme_resources/main/screenshot%204.png)
## Installation
...
'''

synopsis.py
'''python
#!/usr/bin/env python3
import os
import sys
import argparse
import platform
...
'''
```

I suspect it would be easier for LLMs to parse.